### PR TITLE
added check and convert for boolean ssl parameter passed into initializer

### DIFF
--- a/lib/fogbugz-api.rb
+++ b/lib/fogbugz-api.rb
@@ -73,7 +73,7 @@ class FogBugz
   #
   def initialize(url,use_ssl=false,token=nil)
     @url = url
-    @use_ssl = use_ssl
+    @use_ssl = parse_ssl(use_ssl)
     connect
 
     # Attempt to grap api.xml file from the server specified by url.  Will let
@@ -557,6 +557,15 @@ class FogBugz
     @connection = Net::HTTP.new(@url, @use_ssl ? 443 : 80) 
     @connection.use_ssl = @use_ssl
     @connection.verify_mode = OpenSSL::SSL::VERIFY_NONE if @use_ssl
+  end
+
+  # make sure ssl input isn't a string
+  def parse_ssl(ssl)
+    if ssl.class == String
+      ssl.upcase == "TRUE" ? true : false
+     else
+       ssl
+    end
   end
 
   def case_process(cmd,params,cols)


### PR DESCRIPTION
added check and convert for boolean ssl parameter passed into initializer as a string

While running your test I could not get the following to pass - 

> ruby ./test_search.rb myserver.com false myuser mypassword

If this isn't the way I should be calling the test please correct me.

Even though I could kick up irb and manually make the api calls and everything would work fine. It seems that passing 'false' on the commandline converts false to a string and when the ssl check is performed false returns true causing 443 to appear as the port, thus causing a failing test for an installation which doesn't use https (I'm testing this on windows btw - so mayhaps it's different on a linux box).

So anyway I added a simple check to see if the param passed in is a string, and does a conversion if it is.  I'm new to ruby so please provide me feedback if it looks like C#, I'd be happy to make the changes more idiomatic.
